### PR TITLE
Update docker image source

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -36,7 +36,7 @@ stirling_pdf_systemd_wanted_services_list_custom: []
 
 couchdb_container_additional_mounts: []
 
-stirling_pdf_version: 0.33.0-fat
+stirling_pdf_version: 0.39.0-fat
 
 # Project source code URL: https://github.com/Stirling-Tools/Stirling-PDF
 stirling_pdf_container_image: "{{ stirling_pdf_container_image_registry_prefix }}stirlingtools/stirling-pdf:{{ stirling_pdf_container_image_tag }}"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -39,7 +39,7 @@ couchdb_container_additional_mounts: []
 stirling_pdf_version: 0.33.0-fat
 
 # Project source code URL: https://github.com/Stirling-Tools/Stirling-PDF
-stirling_pdf_container_image: "{{ stirling_pdf_container_image_registry_prefix }}frooodle/s-pdf:{{ stirling_pdf_container_image_tag }}"
+stirling_pdf_container_image: "{{ stirling_pdf_container_image_registry_prefix }}stirlingtools/stirling-pdf:{{ stirling_pdf_container_image_tag }}"
 stirling_pdf_container_image_registry_prefix: docker.io/
 stirling_pdf_container_image_tag: "{{ stirling_pdf_version }}"
 stirling_pdf_container_image_force_pull: "{{ stirling_pdf_container_image.endswith(':latest') }}"


### PR DESCRIPTION
First of all, thank you for the role!
I've updated the docker image source as since the [0.33.1 release](https://github.com/Stirling-Tools/Stirling-PDF/releases/tag/v0.33.1) they are moving to a new docker hub user. Though new releases are still available at the old user.
I've also updated to the latest version.