### PR TITLE
add option to change container tmpfs size

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -19,6 +19,9 @@ stirling_pdf_trainingData_path: "{{ stirling_pdf_data_path }}/trainingData"
 stirling_pdf_env_path: "{{ stirling_pdf_config_path }}/env"
 stirling_pdf_logs_path: "{{ stirling_pdf_data_path }}/logs"
 
+# temporary folder used for processing - large pdfs may require larger space
+stirling_pdf_container_tmpfs_size: "100m"
+
 stirling_pdf_extra_config: ''
 
 # to download calibre onto stirling-pdf enabling pdf to/from book and advanced html conversion

--- a/templates/stirling_pdf.service.j2
+++ b/templates/stirling_pdf.service.j2
@@ -32,7 +32,7 @@ ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} create \
                 --mount type=bind,src={{ stirling_pdf_data_path }}/config,dst=/configs \
                 --mount type=bind,src={{ stirling_pdf_trainingData_path }},dst=/usr/share/tessdata \
                 --mount type=bind,src={{ stirling_pdf_data_path }}/customFiles,dst=/customFiles \
-                --tmpfs=/tmp:rw,noexec,nosuid,size=100m \
+                --tmpfs=/tmp:rw,noexec,nosuid,size={{ stirling_pdf_container_tmpfs_size }} \
                 --env-file={{ stirling_pdf_env_path }} \
                 {{ stirling_pdf_container_image }}
 


### PR DESCRIPTION
I ran out of space when merging large pdfs. Using this option one can extend the temporary storage space, so this issue can be avoided.