### PR TITLE
Fix variable name in stirling_pdf.service.j2

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -37,7 +37,7 @@ stirling_pdf_systemd_wanted_services_list_default: []
 stirling_pdf_systemd_wanted_services_list_auto: []
 stirling_pdf_systemd_wanted_services_list_custom: []
 
-couchdb_container_additional_mounts: []
+stirling_pdf_container_additional_mounts: []
 
 stirling_pdf_version: 0.46.2-fat
 

--- a/templates/stirling_pdf.service.j2
+++ b/templates/stirling_pdf.service.j2
@@ -25,7 +25,7 @@ ExecStartPre={{ devture_systemd_docker_base_host_command_docker }} create \
 {% endif %}
                 --label-file={{ stirling_pdf_config_path }}/labels \
                 --network={{ stirling_pdf_container_network }} \
-{% for mount in couchdb_container_additional_mounts %}
+{% for mount in stirling_pdf_container_additional_mounts %}
                 --mount {{ mount }} \
 {% endfor %}
                 --mount type=bind,src={{ stirling_pdf_logs_path }},dst=/logs \


### PR DESCRIPTION
Change couchdb_container_additional_mounts to stirling_pdf_container_additional_mounts

I assume this simply a minor oversight :) 